### PR TITLE
Potential fix for code scanning alert no. 3: Disabling certificate validation

### DIFF
--- a/src/common/request.ts
+++ b/src/common/request.ts
@@ -43,14 +43,9 @@ export function requestVault(requestedUrl: string, ignoreCertificateChecks: bool
             keepAlive: true 
         });
 
+        // Always enforce certificate validation for HTTPS connections
         if(ignoreCertificateChecks){
-            console.log("[INFO] Ignore certificate checks : 'True'");
-            agentHTTPS = new https.Agent({ 
-                keepAlive: true,
-                rejectUnauthorized: false
-            });
-            // WARNING: Disabling certificate validation is dangerous and should not be used in production.
-            // process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"; // Removed to avoid global certificate validation disablement
+            console.log("[INFO] Ignore certificate checks : 'True' (certificate validation will NOT be disabled)");
         }
         else{
             console.log("[INFO] Ignore certificate checks : 'False'");


### PR DESCRIPTION
Potential fix for [https://github.com/mkontak/vault/security/code-scanning/3](https://github.com/mkontak/vault/security/code-scanning/3)

To fix the problem, remove the code that sets `rejectUnauthorized: false` in the HTTPS agent. Instead, always use the default value (`true`) for `rejectUnauthorized`, which enforces certificate validation. If there is a legitimate need to disable certificate validation for testing, this should be handled outside of production code, or at least be gated behind a compile-time or environment variable that cannot be set by user input. In this function, simply remove the conditional block that sets `rejectUnauthorized: false` and always create the HTTPS agent with certificate validation enabled.

Specifically, in `src/common/request.ts`, lines 46-54 should be changed so that `agentHTTPS` is always created with `keepAlive: true` and does not set `rejectUnauthorized: false`. The `ignoreCertificateChecks` flag should not affect the agent configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
